### PR TITLE
Disabled default error page and added stack track

### DIFF
--- a/project-service.yml
+++ b/project-service.yml
@@ -10,6 +10,10 @@ server:
   tomcat:
     max-http-post-size: 2MB
     max-swallow-size: 2MB 
+  error:
+    whitelabel:
+      enabled: false
+    include-stacktrace: always
 
 eureka:
   client:


### PR DESCRIPTION
Spring boot normally posts a white label error page, however, it doesn't show stack traces like how tomcat did before.
Disabling the normal white label error page and adding include-stack trace will show stack traces for us.