### PR TITLE
Added initial routing details for Zuul. Does not have a production ad…

### DIFF
--- a/zuul-service.yml
+++ b/zuul-service.yml
@@ -43,6 +43,11 @@ zuul:
       url: http://rpm-264761131.us-east-1.elb.amazonaws.com/project
       strip-prefix: true
       service-id: project-service
+    notification-service:
+      path: /notifications/**
+      sensitiveHeaders:
+      strip-prefix: true
+      service-id: notification-service
       
 management:
   endpoints:


### PR DESCRIPTION
Updated Zuul configuration to have routing rules for the Notification service. Mostly consistent with other service implementation, but does not have a defined URL due to the deployed resource not existing yet.